### PR TITLE
Upgrade SonarCloud scan action to v8.2.0 +semver: major

### DIFF
--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -42,7 +42,7 @@ jobs:
             --output-path lcov.info
 
       - name: SonarCloud scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v8.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar-cloud.yml
+++ b/.github/workflows/sonar-cloud.yml
@@ -46,7 +46,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: https://sonarcloud.io
         with:
           args: >
             -Dsonar.rust.clippy.reportPaths=clippy-report.json

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,2 @@
 sonar.projectKey=guibranco_holiday-api-sdk-rs
 sonar.organization=guibranco
-sonar.host.url=https://sonarcloud.io


### PR DESCRIPTION
## 📑 Description
Upgrade SonarCloud scan action to v8.2.0 +semver: major

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

CI:
- Bump the SonarSource SonarQube scan GitHub Action from v5 to v8.2.0 in the sonar-cloud workflow.