### PR TITLE
chore: add timeout to CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ jobs:
   build-and-test:
     name: Build & Test (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/infisical-secrets-check.yml
+++ b/.github/workflows/infisical-secrets-check.yml
@@ -1,0 +1,26 @@
+name: Infisical secrets check
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  
+  secrets-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+
+      - name: Checkout repo
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Infisical secrets check
+        uses: guibranco/github-infisical-secrets-check-action@v5.1.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
   build-and-test:
     name: Build & Test (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 5
     needs: version
     strategy:
       fail-fast: true


### PR DESCRIPTION
## 📑 Description
Add a timeout of 5 minutes for the build-and-test jobs in both the CI and release GitHub workflows. This ensures that the jobs do not run indefinitely in case of any issues, helping to avoid resource wastage and improve overall CI efficiency.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Add execution time limits to build-and-test jobs and introduce an on-demand/PR secrets scanning workflow.

CI:
- Set a 5-minute timeout for the build-and-test job in the CI workflow.
- Set a 5-minute timeout for the build-and-test job in the release workflow.
- Add a new Infisical-based secrets scanning workflow triggered on pull requests and manual dispatch.